### PR TITLE
feat: 거래내역(TradeHistory) 저장, 수정, 삭제, 조회 기능 및 테스트 추가

### DIFF
--- a/src/main/kotlin/app/api/OcrRoutes.kt
+++ b/src/main/kotlin/app/api/OcrRoutes.kt
@@ -34,5 +34,4 @@ fun Route.ocrRoutes(ocrService: OcrService) {
             call.respond(HttpStatusCode.BadRequest, "파일이 업로드되지 않았습니다.")
         }
     }
-
 }

--- a/src/main/kotlin/app/api/TradeHistoryRoutes.kt
+++ b/src/main/kotlin/app/api/TradeHistoryRoutes.kt
@@ -13,23 +13,33 @@ import io.ktor.server.routing.*
 fun Route.tradeHistoryRoutes(tradeHistoryService: TradeHistoryService) {
     // 전체 조회
     get {
-        tradeHistoryService.findAll()
+        val userId = 1
+        tradeHistoryService.findAllByUserId(userId)
             .onSuccess { call.respond(HttpStatusCode.OK, it) }
             .onError { call.respond(HttpStatusCode.BadRequest, mapOf("error" to it)) }
     }
 
-    // 저장 & 수정
+    // 저장
     post {
         val items = call.receive<List<TradeHistoryRequest>>()
-        tradeHistoryService.saveAndUpdate(items)
-            .onSuccess { call.respond(HttpStatusCode.Created, mapOf("message" to "저장/수정 완료")) }
+        val userId = 1
+        tradeHistoryService.save(items, userId)
+            .onSuccess { call.respond(HttpStatusCode.Created, mapOf("message" to "저장 완료")) }
+            .onError { call.respond(HttpStatusCode.BadRequest, mapOf("error" to it)) }
+    }
+
+    // 수정
+    put {
+        val items = call.receive<List<TradeHistoryRequest>>()
+        tradeHistoryService.update(items)
+            .onSuccess { call.respond(HttpStatusCode.OK, mapOf("message" to "수정 완료")) }
             .onError { call.respond(HttpStatusCode.BadRequest, mapOf("error" to it)) }
     }
 
     // 삭제
     delete {
         val items = call.receive<List<TradeHistoryRequest>>()
-        tradeHistoryService.deleteChecked(items)
+        tradeHistoryService.delete(items)
             .onSuccess { call.respond(HttpStatusCode.OK, mapOf("message" to "삭제 완료")) }
             .onError { call.respond(HttpStatusCode.BadRequest, mapOf("error" to it)) }
     }

--- a/src/main/kotlin/app/api/TradeHistoryRoutes.kt
+++ b/src/main/kotlin/app/api/TradeHistoryRoutes.kt
@@ -1,0 +1,36 @@
+package app.api
+
+import app.domain.tradeHistory.dto.TradeHistoryRequest
+import app.domain.tradeHistory.service.TradeHistoryService
+import app.utils.onError
+import app.utils.onSuccess
+import io.ktor.http.*
+import io.ktor.http.content.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+fun Route.tradeHistoryRoutes(tradeHistoryService: TradeHistoryService) {
+    // 전체 조회
+    get {
+        tradeHistoryService.findAll()
+            .onSuccess { call.respond(HttpStatusCode.OK, it) }
+            .onError { call.respond(HttpStatusCode.BadRequest, mapOf("error" to it)) }
+    }
+
+    // 저장 & 수정
+    post {
+        val items = call.receive<List<TradeHistoryRequest>>()
+        tradeHistoryService.saveAndUpdate(items)
+            .onSuccess { call.respond(HttpStatusCode.Created, mapOf("message" to "저장/수정 완료")) }
+            .onError { call.respond(HttpStatusCode.BadRequest, mapOf("error" to it)) }
+    }
+
+    // 삭제
+    delete {
+        val items = call.receive<List<TradeHistoryRequest>>()
+        tradeHistoryService.deleteChecked(items)
+            .onSuccess { call.respond(HttpStatusCode.OK, mapOf("message" to "삭제 완료")) }
+            .onError { call.respond(HttpStatusCode.BadRequest, mapOf("error" to it)) }
+    }
+}

--- a/src/main/kotlin/app/config/Routing.kt
+++ b/src/main/kotlin/app/config/Routing.kt
@@ -2,10 +2,13 @@ package app.config
 
 import app.api.mapleRoutes
 import app.api.ocrRoutes
+import app.api.tradeHistoryRoutes
 import app.api.userRoutes
 import app.domain.maple.repository.MapleRepository
 import app.domain.maple.service.MapleService
 import app.domain.ocr.service.OcrService
+import app.domain.tradeHistory.repository.TradeHistoryRepository
+import app.domain.tradeHistory.service.TradeHistoryService
 import app.domain.user.repository.UserRepository
 import app.domain.user.service.UserService
 import app.infrastructure.database.DatabaseFactory
@@ -21,9 +24,14 @@ fun Application.configureRouting(client: HttpClient) {
 
     val userRepository = UserRepository(database)
     val userService = UserService(userRepository)
+
     val mapleRepository = MapleRepository(database)
     val mapleService = MapleService(config, client, mapleRepository, userRepository)
+
     val ocrService = OcrService()
+
+    val tradeHistoryRepository = TradeHistoryRepository(database)
+    val tradeHistoryService = TradeHistoryService(tradeHistoryRepository)
 
     routing {
         get("/") {
@@ -40,6 +48,10 @@ fun Application.configureRouting(client: HttpClient) {
 
         route("/api/v1/ocrTest") {
             ocrRoutes(ocrService)
+        }
+
+        route("/api/v1/tradeHistory") {
+            tradeHistoryRoutes(tradeHistoryService)
         }
     }
 }

--- a/src/main/kotlin/app/domain/maple/repository/MapleRepository.kt
+++ b/src/main/kotlin/app/domain/maple/repository/MapleRepository.kt
@@ -14,7 +14,7 @@ class MapleRepository(private val db: Database) {
 
     suspend fun isExists(userId: Int): Boolean = newSuspendedTransaction(Dispatchers.IO, db) {
         MapleUserTable.select { MapleUserTable.userId eq userId }
-            .empty().not() // ✅ 데이터가 있으면 true, 없으면 false 반환
+            .empty().not()
     }
 
     suspend fun findById(id: Int): MapleResponse? {

--- a/src/main/kotlin/app/domain/maple/service/MapleService.kt
+++ b/src/main/kotlin/app/domain/maple/service/MapleService.kt
@@ -28,7 +28,7 @@ class MapleService(config: ApplicationConfig,
 ) {
     private val logger = LoggerFactory.getLogger(MapleService::class.java)
 //    private val apiKey: String = config.property("maple.apiKey").getString()
-    private val apiKey: String = "test_2a550831e8b2c1a4360fce104d32a4958e07a625226f41463ce7c72d466dce8fefe8d04e6d233bd35cf2fabdeb93fb0d"
+    private val apiKey: String = "1"
     suspend fun getMapleUser(nickname: String): APIResult<MapleUser, String> {
         if (nickname.isBlank()) return Error("닉네임을 입력해주세요.")
 

--- a/src/main/kotlin/app/domain/ocr/dto/OcrResponse.kt
+++ b/src/main/kotlin/app/domain/ocr/dto/OcrResponse.kt
@@ -1,0 +1,14 @@
+package app.domain.ocr.dto
+
+import app.utils.TradeStatus
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OcrResponse(
+    var tradeDate : String,
+    var itemName : String,
+    var price : Int,
+    var korPrice: String,
+    var status : TradeStatus,
+
+)

--- a/src/main/kotlin/app/domain/tradeHistory/dto/TradeHistoryRequest.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/dto/TradeHistoryRequest.kt
@@ -9,7 +9,6 @@ data class TradeHistoryRequest (
     val price: Int,
     val korPrice: String,
     val status: TradeStatus,
-    val userId: Int,
     val isChecked: Boolean = false,
     val isDeleted: Boolean = false
 )

--- a/src/main/kotlin/app/domain/tradeHistory/dto/TradeHistoryRequest.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/dto/TradeHistoryRequest.kt
@@ -1,0 +1,15 @@
+package app.domain.tradeHistory.dto
+
+import app.utils.TradeStatus
+
+data class TradeHistoryRequest (
+    val id: Int? = null,
+    val tradeDate: String,
+    val itemName: String,
+    val price: Int,
+    val korPrice: String,
+    val status: TradeStatus,
+    val userId: Int,
+    val isChecked: Boolean = false,
+    val isDeleted: Boolean = false
+)

--- a/src/main/kotlin/app/domain/tradeHistory/dto/TradeHistoryResponse.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/dto/TradeHistoryResponse.kt
@@ -1,0 +1,15 @@
+package app.domain.tradeHistory.dto
+
+import app.utils.TradeStatus
+
+data class TradeHistoryResponse (
+    val id: Int,
+    val tradeDate: String,
+    val itemName: String,
+    val price: Int,
+    val korPrice: String,
+    val status: TradeStatus,
+    val userId: Int,
+    val isChecked: Boolean = false,
+    val isDeleted: Boolean = false
+)

--- a/src/main/kotlin/app/domain/tradeHistory/model/TradeHistory.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/model/TradeHistory.kt
@@ -1,0 +1,43 @@
+package app.domain.tradeHistory.model
+
+import app.domain.tradeHistory.dto.TradeHistoryResponse
+import app.utils.TradeStatus
+import org.jetbrains.exposed.sql.ResultRow
+
+data class TradeHistory(
+    val id: Int,
+    val tradeDate: String,
+    val itemName: String,
+    val price: Int,
+    val korPrice: String,
+    val status: TradeStatus,
+    val userId: Int
+) {
+    companion object {
+        fun fromRow(row: ResultRow): TradeHistory {
+            return TradeHistory(
+                id = row[TradeHistoryTable.id].value,
+                tradeDate = row[TradeHistoryTable.tradeDate],
+                itemName = row[TradeHistoryTable.itemName],
+                price = row[TradeHistoryTable.price],
+                korPrice = row[TradeHistoryTable.korPrice],
+                status = row[TradeHistoryTable.status],
+                userId = row[TradeHistoryTable.userId].value
+            )
+        }
+    }
+
+    fun toResponse(): TradeHistoryResponse {
+        return TradeHistoryResponse(
+            id = id,
+            tradeDate = tradeDate,
+            itemName = itemName,
+            price = price,
+            korPrice = korPrice,
+            status = status,
+            userId = userId,
+            isChecked = false,
+            isDeleted = false
+        )
+    }
+}

--- a/src/main/kotlin/app/domain/tradeHistory/model/TradeHistoryTable.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/model/TradeHistoryTable.kt
@@ -7,7 +7,7 @@ import org.jetbrains.exposed.sql.ReferenceOption
 
 
 object TradeHistoryTable : IntIdTable("trade_history") {
-    val tradeDate = varchar("trade_date", 20) // ✅ 거래일
+    val tradeDate = varchar("trade_date", 30) // ✅ 거래일
     val itemName = varchar("item_name", 50) // ✅ 아이템명
     val price = integer("price") // ✅ 가격
     val korPrice = varchar("kor_price", 20) // ✅ 한화 가격

--- a/src/main/kotlin/app/domain/tradeHistory/model/TradeHistoryTable.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/model/TradeHistoryTable.kt
@@ -1,0 +1,16 @@
+package app.domain.tradeHistory.model
+
+import app.domain.user.model.UserTable
+import app.utils.TradeStatus
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.ReferenceOption
+
+
+object TradeHistoryTable : IntIdTable("trade_history") {
+    val tradeDate = varchar("trade_date", 20) // ✅ 거래일
+    val itemName = varchar("item_name", 50) // ✅ 아이템명
+    val price = integer("price") // ✅ 가격
+    val korPrice = varchar("kor_price", 20) // ✅ 한화 가격
+    val status = enumerationByName("status", 20, TradeStatus::class) // ✅ 거래 상태
+    val userId = reference("user_id", UserTable.id, onDelete = ReferenceOption.CASCADE) // ✅ 외래키 추가 (UserTable 연결)
+}

--- a/src/main/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepository.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepository.kt
@@ -3,26 +3,32 @@ package app.domain.tradeHistory.repository
 import app.domain.tradeHistory.dto.TradeHistoryRequest
 import app.domain.tradeHistory.model.TradeHistory
 import app.domain.tradeHistory.model.TradeHistoryTable
+import app.domain.user.model.UserTable
 import kotlinx.coroutines.Dispatchers
+import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 
 class TradeHistoryRepository(private val db: Database) {
 
+    suspend fun findById(id: Int): TradeHistory? = newSuspendedTransaction(Dispatchers.IO, db) {
+        TradeHistoryTable.select { TradeHistoryTable.id eq id }.map { TradeHistory.fromRow(it) }.firstOrNull()
+    }
+
     suspend fun findAll(): List<TradeHistory> = newSuspendedTransaction(Dispatchers.IO, db) {
         TradeHistoryTable.selectAll().map { TradeHistory.fromRow(it) }
     }
 
-    suspend fun save(item: TradeHistoryRequest) = newSuspendedTransaction(Dispatchers.IO, db) {
-        TradeHistoryTable.insert {
+    suspend fun save(item: TradeHistoryRequest, userId: Int) = newSuspendedTransaction(Dispatchers.IO, db) {
+        TradeHistoryTable.insertAndGetId {
             it[tradeDate] = item.tradeDate
             it[itemName] = item.itemName
             it[price] = item.price
             it[korPrice] = item.korPrice
             it[status] = item.status
-            it[userId] = item.userId
-        }
+            it[TradeHistoryTable.userId] = EntityID(userId, UserTable)
+        }.value
     }
 
     suspend fun update(item: TradeHistoryRequest) = newSuspendedTransaction(Dispatchers.IO, db) {
@@ -32,7 +38,6 @@ class TradeHistoryRepository(private val db: Database) {
             it[price] = item.price
             it[korPrice] = item.korPrice
             it[status] = item.status
-            it[userId] = item.userId
         }
     }
 

--- a/src/main/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepository.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepository.kt
@@ -16,8 +16,9 @@ class TradeHistoryRepository(private val db: Database) {
         TradeHistoryTable.select { TradeHistoryTable.id eq id }.map { TradeHistory.fromRow(it) }.firstOrNull()
     }
 
-    suspend fun findAll(): List<TradeHistory> = newSuspendedTransaction(Dispatchers.IO, db) {
-        TradeHistoryTable.selectAll().map { TradeHistory.fromRow(it) }
+    suspend fun findAllByUserId(userId : Int): List<TradeHistory> = newSuspendedTransaction(Dispatchers.IO, db) {
+        TradeHistoryTable.select(TradeHistoryTable.userId eq userId)
+            .map { TradeHistory.fromRow(it) }
     }
 
     suspend fun save(item: TradeHistoryRequest, userId: Int) = newSuspendedTransaction(Dispatchers.IO, db) {

--- a/src/main/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepository.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepository.kt
@@ -1,0 +1,42 @@
+package app.domain.tradeHistory.repository
+
+import app.domain.tradeHistory.dto.TradeHistoryRequest
+import app.domain.tradeHistory.model.TradeHistory
+import app.domain.tradeHistory.model.TradeHistoryTable
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+
+class TradeHistoryRepository(private val db: Database) {
+
+    suspend fun findAll(): List<TradeHistory> = newSuspendedTransaction(Dispatchers.IO, db) {
+        TradeHistoryTable.selectAll().map { TradeHistory.fromRow(it) }
+    }
+
+    suspend fun save(item: TradeHistoryRequest) = newSuspendedTransaction(Dispatchers.IO, db) {
+        TradeHistoryTable.insert {
+            it[tradeDate] = item.tradeDate
+            it[itemName] = item.itemName
+            it[price] = item.price
+            it[korPrice] = item.korPrice
+            it[status] = item.status
+            it[userId] = item.userId
+        }
+    }
+
+    suspend fun update(item: TradeHistoryRequest) = newSuspendedTransaction(Dispatchers.IO, db) {
+        TradeHistoryTable.update({ TradeHistoryTable.id eq item.id!! }) {
+            it[tradeDate] = item.tradeDate
+            it[itemName] = item.itemName
+            it[price] = item.price
+            it[korPrice] = item.korPrice
+            it[status] = item.status
+            it[userId] = item.userId
+        }
+    }
+
+    suspend fun delete(id: Int) = newSuspendedTransaction(Dispatchers.IO, db) {
+        TradeHistoryTable.deleteWhere { TradeHistoryTable.id eq id }
+    }
+}

--- a/src/main/kotlin/app/domain/tradeHistory/service/TradeHistoryService.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/service/TradeHistoryService.kt
@@ -13,11 +13,12 @@ class TradeHistoryService(
     }
 
     suspend fun saveAndUpdate(items: List<TradeHistoryRequest>): APIResult<String, String> {
+        var userId = 1
         items.filter { it.isChecked }.forEach { item ->
             if (item.id != null) {
                 tradeHistoryRepository.update(item)
             } else {
-                tradeHistoryRepository.save(item)
+                tradeHistoryRepository.save(item,userId)
             }
         }
         return APIResult.Success("저장되었습니다.")

--- a/src/main/kotlin/app/domain/tradeHistory/service/TradeHistoryService.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/service/TradeHistoryService.kt
@@ -1,0 +1,31 @@
+package app.domain.tradeHistory.service
+
+import app.domain.tradeHistory.dto.TradeHistoryRequest
+import app.domain.tradeHistory.dto.TradeHistoryResponse
+import app.domain.tradeHistory.repository.TradeHistoryRepository
+import app.utils.APIResult
+
+class TradeHistoryService(
+    private val tradeHistoryRepository: TradeHistoryRepository
+) {
+    suspend fun findAll(): APIResult.Success<List<TradeHistoryResponse>> {
+        return APIResult.Success(tradeHistoryRepository.findAll().map { it.toResponse() })
+    }
+
+    suspend fun saveAndUpdate(items: List<TradeHistoryRequest>): APIResult<String, String> {
+        items.filter { it.isChecked }.forEach { item ->
+            if (item.id != null) {
+                tradeHistoryRepository.update(item)
+            } else {
+                tradeHistoryRepository.save(item)
+            }
+        }
+        return APIResult.Success("저장되었습니다.")
+    }
+
+    suspend fun deleteChecked(items: List<TradeHistoryRequest>): APIResult<String, String> {
+        items.filter { it.isChecked && it.isDeleted && it.id != null }
+            .forEach { tradeHistoryRepository.delete(it.id!!) }
+        return APIResult.Success("삭제되었습니다.")
+    }
+}

--- a/src/main/kotlin/app/domain/tradeHistory/service/TradeHistoryService.kt
+++ b/src/main/kotlin/app/domain/tradeHistory/service/TradeHistoryService.kt
@@ -8,23 +8,24 @@ import app.utils.APIResult
 class TradeHistoryService(
     private val tradeHistoryRepository: TradeHistoryRepository
 ) {
-    suspend fun findAll(): APIResult.Success<List<TradeHistoryResponse>> {
-        return APIResult.Success(tradeHistoryRepository.findAll().map { it.toResponse() })
+    suspend fun findAllByUserId(userId : Int): APIResult.Success<List<TradeHistoryResponse>> {
+        return APIResult.Success(tradeHistoryRepository.findAllByUserId(userId).map { it.toResponse() })
     }
 
-    suspend fun saveAndUpdate(items: List<TradeHistoryRequest>): APIResult<String, String> {
-        var userId = 1
+    suspend fun save(items: List<TradeHistoryRequest>, userId: Int): APIResult<String, String> {
         items.filter { it.isChecked }.forEach { item ->
-            if (item.id != null) {
-                tradeHistoryRepository.update(item)
-            } else {
-                tradeHistoryRepository.save(item,userId)
-            }
+            tradeHistoryRepository.save(item,userId)
         }
         return APIResult.Success("저장되었습니다.")
     }
 
-    suspend fun deleteChecked(items: List<TradeHistoryRequest>): APIResult<String, String> {
+    suspend fun update(items: List<TradeHistoryRequest>): APIResult<String, String> {
+        items.filter { it.isChecked && !it.isDeleted && it.id != null }
+            .forEach { tradeHistoryRepository.update(it) }
+        return APIResult.Success("수정되었습니다.")
+    }
+
+    suspend fun delete(items: List<TradeHistoryRequest>): APIResult<String, String> {
         items.filter { it.isChecked && it.isDeleted && it.id != null }
             .forEach { tradeHistoryRepository.delete(it.id!!) }
         return APIResult.Success("삭제되었습니다.")

--- a/src/main/kotlin/app/utils/TradeStatus.kt
+++ b/src/main/kotlin/app/utils/TradeStatus.kt
@@ -1,0 +1,5 @@
+package app.utils
+
+enum class TradeStatus {
+    COMPLETE, CANCEL
+}

--- a/src/test/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepositoryTest.kt
+++ b/src/test/kotlin/app/domain/tradeHistory/repository/TradeHistoryRepositoryTest.kt
@@ -1,0 +1,179 @@
+package app.domain.tradeHistory.repository
+
+import app.domain.tradeHistory.dto.TradeHistoryRequest
+import app.domain.tradeHistory.model.TradeHistoryTable
+import app.domain.user.model.User
+import app.domain.user.model.UserTable
+import app.domain.user.repository.UserRepository
+import app.infrastructure.database.DatabaseFactory
+import app.utils.TradeStatus
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.config.*
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import java.time.LocalDateTime
+import kotlin.test.Test
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+
+class TradeHistoryRepositoryTest {
+
+    private val config = HoconApplicationConfig(ConfigFactory.load("application.yaml"))
+
+    private val database = DatabaseFactory.init(config)
+    private lateinit var tradeHistoryRepository: TradeHistoryRepository
+    private lateinit var userRepository: UserRepository
+
+    @BeforeAll
+    fun setup() {
+        transaction(database) {
+            SchemaUtils.create(TradeHistoryTable, UserTable)
+        }
+        tradeHistoryRepository = TradeHistoryRepository(database)
+        userRepository = UserRepository(database)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        transaction(database) {
+            TradeHistoryTable.deleteAll()
+            UserTable.deleteAll()
+        }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        transaction {
+            SchemaUtils.drop(TradeHistoryTable)
+            SchemaUtils.drop(UserTable)
+        }
+    }
+
+    @Test
+    fun `insert - 새로운 거래내역 데이터를 저장할 수 있어야 한다`() = runBlocking {
+        // Given
+        val createUser = User(username = "wycUser", password = "wycPassword123")
+        val userId = userRepository.create(createUser)
+
+        val tradeHistoryRequest = TradeHistoryRequest(
+            id = null,
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "아이템1",
+            price = 1000,
+            korPrice = "(1,000원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+
+        // When
+        val tradeHistoryId = tradeHistoryRepository.save(tradeHistoryRequest, userId)
+
+        var tradeHistory = tradeHistoryRepository.findById(tradeHistoryId)
+
+        // Then
+        assertNotNull(tradeHistory)
+        assertEquals("아이템1", tradeHistory?.itemName)
+        assertEquals(1000, tradeHistory?.price)
+        assertEquals("(1,000원)", tradeHistory?.korPrice)
+        assertEquals(TradeStatus.COMPLETE, tradeHistory?.status)
+        assertEquals(userId, tradeHistory?.userId)
+    }
+
+    @Test
+    fun `update - 거래내역 데이터를 수정할 수 있어야 한다`() = runBlocking {
+        // Given
+        val createUser = User(username = "wycUser", password = "wycPassword123")
+        val userId = userRepository.create(createUser)
+
+        val tradeHistoryRequest = TradeHistoryRequest(
+            id = null,
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "아이템1",
+            price = 1000,
+            korPrice = "(1,000원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+
+        val tradeHistoryId = tradeHistoryRepository.save(tradeHistoryRequest, userId)
+
+        // When
+        val changeHistoryRequest = TradeHistoryRequest(
+            id = tradeHistoryId,
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "아이템2",
+            price = 2000,
+            korPrice = "(2,000원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+        tradeHistoryRepository.update(changeHistoryRequest)
+
+        val historyList = tradeHistoryRepository.findAllByUserId(userId)
+
+        // Then
+        assertNotNull(historyList)
+        assertEquals(1, historyList.size)
+        assertEquals("아이템2", historyList[0].itemName)
+        assertEquals(2000, historyList[0].price)
+    }
+
+    @Test
+    fun `update - 존재하지 않는 거래내역 수정 시 아무 일도 일어나지 않아야 한다`() = runBlocking {
+        val updateRequest = TradeHistoryRequest(
+            id = 99999, // 없는 ID
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "잘못된 데이터",
+            price = 0,
+            korPrice = "(0원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+
+        tradeHistoryRepository.update(updateRequest)
+
+        val all = tradeHistoryRepository.findAllByUserId(1)
+        assertEquals(0, all.size)
+    }
+
+    @Test
+    fun `delete - 거래내역 데이터를 삭제할 수 있어야 한다`() = runBlocking {
+        // Given
+        val createUser = User(username = "wycUser", password = "wycPassword123")
+        val userId = userRepository.create(createUser)
+
+        val tradeHistoryRequest = TradeHistoryRequest(
+            id = null,
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "아이템1",
+            price = 1000,
+            korPrice = "(1,000원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+
+        val tradeHistoryId = tradeHistoryRepository.save(tradeHistoryRequest, userId)
+
+        // When
+        tradeHistoryRepository.delete(tradeHistoryId)
+
+        val historyList = tradeHistoryRepository.findAllByUserId(userId)
+
+        // Then
+        assertNotNull(historyList)
+        assertEquals(0, historyList.size)
+    }
+}

--- a/src/test/kotlin/app/domain/tradeHistory/service/TradeHistoryServiceTest.kt
+++ b/src/test/kotlin/app/domain/tradeHistory/service/TradeHistoryServiceTest.kt
@@ -1,0 +1,219 @@
+package app.domain.tradeHistory.service
+
+import app.domain.tradeHistory.dto.TradeHistoryRequest
+import app.domain.tradeHistory.model.TradeHistoryTable
+import app.domain.tradeHistory.repository.TradeHistoryRepository
+import app.domain.user.model.User
+import app.domain.user.model.UserTable
+import app.domain.user.repository.UserRepository
+import app.infrastructure.database.DatabaseFactory
+import app.utils.TradeStatus
+import com.typesafe.config.ConfigFactory
+import io.ktor.server.config.*
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import java.time.LocalDateTime
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TradeHistoryServiceTest{
+    private val config = HoconApplicationConfig(ConfigFactory.load("application.yaml"))
+    private val database = DatabaseFactory.init(config)
+
+    private lateinit var tradeHistoryService: TradeHistoryService
+    private lateinit var tradeHistoryRepository: TradeHistoryRepository
+    private lateinit var userRepository: UserRepository
+
+    @BeforeAll
+    fun setup() {
+        transaction(database) {
+            SchemaUtils.create(TradeHistoryTable, UserTable)
+        }
+        tradeHistoryRepository = TradeHistoryRepository(database)
+        userRepository = UserRepository(database)
+        tradeHistoryService = TradeHistoryService(tradeHistoryRepository)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        transaction(database) {
+            TradeHistoryTable.deleteAll()
+            UserTable.deleteAll()
+        }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        transaction {
+            SchemaUtils.drop(TradeHistoryTable)
+            SchemaUtils.drop(UserTable)
+        }
+    }
+
+    @Test
+    fun `findAll - 거래내역을 전체 조회할 수 있어야 한다`() = runBlocking {
+        // Given
+        val createUser = User(username = "wycUser", password = "wycPassword123")
+        val userId = userRepository.create(createUser)
+
+        val tradeHistoryRequestList = listOf(
+            TradeHistoryRequest(
+                id = null,
+                tradeDate = LocalDateTime.now().toString(),
+                itemName = "아이템1",
+                price = 1000,
+                korPrice = "(1,000원)",
+                status = TradeStatus.COMPLETE,
+                isChecked = true,
+                isDeleted = false
+            ),
+            TradeHistoryRequest(
+                id = null,
+                tradeDate = LocalDateTime.now().toString(),
+                itemName = "아이템2",
+                price = 2000,
+                korPrice = "(2,000원)",
+                status = TradeStatus.COMPLETE,
+                isChecked = true,
+                isDeleted = false
+        ))
+
+        tradeHistoryService.save(tradeHistoryRequestList, userId)
+
+        // When
+        val result = tradeHistoryService.findAllByUserId(userId)
+        // Then
+        assertNotNull(result)
+        assertEquals(2, result.data.size)
+        assertEquals("아이템1", result.data[0].itemName)
+    }
+
+    @Test
+    fun `save - 거래내역을 저장할 수 있어야 한다`() = runBlocking {
+        // Given
+        val createUser = User(username = "wycUser", password = "wycPassword123")
+        val userId = userRepository.create(createUser)
+
+        val tradeHistoryRequest = TradeHistoryRequest(
+            id = null,
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "아이템1",
+            price = 1000,
+            korPrice = "(1,000원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+
+        // When
+        tradeHistoryService.save(listOf(tradeHistoryRequest), userId)
+
+        val tradeHistory = tradeHistoryService.findAllByUserId(userId).data.first()
+
+        // Then
+        assertNotNull(tradeHistory)
+        assertEquals("아이템1", tradeHistory.itemName)
+        assertEquals(1000, tradeHistory.price)
+        assertEquals("(1,000원)", tradeHistory.korPrice)
+        assertEquals(TradeStatus.COMPLETE, tradeHistory.status)
+    }
+
+    @Test
+    fun `update - 거래내역을 수정할 수 있어야 한다`() = runBlocking {
+        // Given
+        val createUser = User(username = "wycUser", password = "wycPassword123")
+        val userId = userRepository.create(createUser)
+
+        val tradeHistoryRequest = TradeHistoryRequest(
+            id = null,
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "아이템1",
+            price = 1000,
+            korPrice = "(1,000원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+
+        tradeHistoryService.save(listOf(tradeHistoryRequest), userId)
+
+        val tradeHistoryId = tradeHistoryService.findAllByUserId(userId).data.first().id
+
+        // When
+        val changeHistoryRequest = TradeHistoryRequest(
+            id = tradeHistoryId,
+            tradeDate = LocalDateTime.now().toString(),
+            itemName = "아이템2",
+            price = 2000,
+            korPrice = "(2,000원)",
+            status = TradeStatus.COMPLETE,
+            isChecked = true,
+            isDeleted = false
+        )
+        tradeHistoryService.update(listOf(changeHistoryRequest))
+
+        val historyList = tradeHistoryService.findAllByUserId(userId).data
+
+        // Then
+        assertNotNull(historyList)
+        assertEquals(1, historyList.size)
+        assertEquals("아이템2", historyList[0].itemName)
+    }
+
+    @Test
+    fun `deleteChecked - 체크된 거래내역을 삭제할 수 있어야 한다`() = runBlocking {
+        // Given
+        val createUser = User(username = "wycUser", password = "wycPassword123")
+        val userId = userRepository.create(createUser)
+
+        val tradeHistoryRequestList = listOf(
+            TradeHistoryRequest(
+                id = null,
+                tradeDate = LocalDateTime.now().toString(),
+                itemName = "아이템1",
+                price = 1000,
+                korPrice = "(1,000원)",
+                status = TradeStatus.COMPLETE,
+                isChecked = true,
+                isDeleted = false
+            ),
+            TradeHistoryRequest(
+                id = null,
+                tradeDate = LocalDateTime.now().toString(),
+                itemName = "아이템2",
+                price = 2000,
+                korPrice = "(2,000원)",
+                status = TradeStatus.COMPLETE,
+                isChecked = true,
+                isDeleted = false
+        ))
+
+        tradeHistoryService.save(tradeHistoryRequestList, userId)
+        val savedHistoryList = tradeHistoryService.findAllByUserId(userId)
+        val deleteRequest = listOf(
+            TradeHistoryRequest(
+                id = savedHistoryList.data[0].id,
+                tradeDate = LocalDateTime.now().toString(),
+                itemName = "아이템1",
+                price = 1000,
+                korPrice = "(1,000원)",
+                status = TradeStatus.COMPLETE,
+                isChecked = true,
+                isDeleted = true
+            )
+        )
+
+        // When
+        tradeHistoryService.delete(deleteRequest)
+
+        val result = tradeHistoryService.findAllByUserId(userId)
+        // Then
+        assertNotNull(result)
+        assertEquals(1, result.data.size)
+        assertEquals("아이템2", result.data[0].itemName)
+    }
+}


### PR DESCRIPTION
- TradeHistory 테이블 생성 및 TradeStatus enum 정의
- TradeHistory 모델에 ResultRow 매핑 함수(fromRow) 및 toResponse 추가
- 거래내역 요청/응답용 DTO (TradeHistoryRequest, TradeHistoryResponse) 생성
- TradeHistoryRepository: 전체 조회, 저장/수정(saveOrUpdate), 삭제(deleteByIds) 로직 구현
- TradeHistoryService: 비즈니스 로직 처리
- 거래내역 관련 라우트 연결 (/trade-history)
- isChecked 기반 저장/수정 처리, isDeleted 기반 삭제 처리
- OCR 결과 DTO (OcrResponse) → TradeHistoryRequest 변환 구조 정리
- Unit 테스트 및 통합 테스트 작성 (service/repository)
- User 연관관계 설정 및 테스트 데이터 생성